### PR TITLE
Update README.md to add `scope=write_access` to token request

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Creating an access token for Enterpise can sometimes be tricky for people who ha
 
 * Go to the page where you created your API key. Take note of the "Client ID" associated with your API key.
 * Go to the following URL, replacing the base URL, the `client_id`, and base URL of the `redirect_uri` with your own:
-`https://YOUR.SO-ENTERPRISE.URL/oauth/dialog?client_id=111&redirect_uri=https://YOUR.SO-ENTERPRISE.URL/oauth/login_success`
+`https://YOUR.SO-ENTERPRISE.URL/oauth/dialog?client_id=111&redirect_uri=https://YOUR.SO-ENTERPRISE.URL/oauth/login_success&scope=write_access`
 * You may be prompted to login to Stack Overflow Enterprise, if you're not already. Either way, you'll be redirected to a page that simply says "Authorizing Application"
 * In the URL of that page, you'll find your access token. Example: `https://YOUR.SO-ENTERPRISE.URL/oauth/login_success#access_token=YOUR_TOKEN`
 


### PR DESCRIPTION
When requesting your API access token, it's essential to specify that you want a WRITE token. Otherwise, the question/answer write API call will fail with a 403 Forbidden error.

I learned this via StackOverflow support ticket 128578.